### PR TITLE
Fix high score font size

### DIFF
--- a/game.js
+++ b/game.js
@@ -358,10 +358,10 @@ function draw() {
     // Draw Score
 	ctx.textAlign = "center";
     ctx.fillStyle = "white";
-    ctx.font = unite+"px Arial";
-    ctx.fillText("score "+score, txt_score_x, txt_score_y);
-	ctx.font = unite+"40px Arial";
-    ctx.fillText("High Score: " + highScore, txt_score_x, txt_score_y-1.5*unite);
+    ctx.font = unite + "px Arial";
+    ctx.fillText("score " + score, txt_score_x, txt_score_y);
+    ctx.font = "40px Arial";
+    ctx.fillText("High Score: " + highScore, txt_score_x, txt_score_y - 1.5 * unite);
 	
 	
 	


### PR DESCRIPTION
## Summary
- fix high score text rendering by using the intended 40px font size

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_6868e0065e4c8324a219cd9af9512fce